### PR TITLE
Chrome's logo is composed of radial gradients, not linear gradients

### DIFF
--- a/logos/chrome.svg
+++ b/logos/chrome.svg
@@ -4,7 +4,7 @@
    <stop stop-color="#81b4e0"/>
    <stop stop-color="#0c5a94" offset="1"/>
   </linearGradient>
-  <linearGradient id="r" x2="0" x1="0" y1="16" y2="107" gradientUnits="userSpaceOnUse">
+  <radialGradient id="r" x2="0" x1="0" y1="0" y2="100%">
    <stop stop-color="#f06b59"/>
    <stop stop-color="#df2227" offset="1"/>
   </linearGradient>


### PR DESCRIPTION
Here I've adjusted it as close as I could,  for reference

http://paulirish.com/lovesyou/new-browser-logos/chrome-512.png

Still not 100% accurate but closer than the existing solution.
