### PR TITLE
Corrected Internet Explorer: 5195 bytes

### DIFF
--- a/logos/ie.svg
+++ b/logos/ie.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 109.40017 100.77499">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 100.775">
  <radialGradient id="c" gradientUnits="userSpaceOnUse" cy="169.83791" cx="157.0107" gradientTransform="matrix(.869 .4949 -.4095 .7191 90.1259 -29.9967)" r="175.4256">
   <stop stop-color="#3dc5f1" offset=".4713"/>
   <stop stop-color="#31a5dc" offset=".7905"/>


### PR DESCRIPTION
The IE logo motif should be centered in the viewBox.

(Probably ought to rephrase the README to convey this somehow, too.)
