### PR TITLE
Imgur: 615 bytes

### DIFF
--- a/logos/imgur.svg
+++ b/logos/imgur.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<defs>
+		<linearGradient id="ImgurGreenGradient" x1="0" y1="0" x2="0" y2="1">
+			<stop stop-color="#8fca57" offset="0"/>
+			<stop stop-color="#6fb826" offset="0.5"/>
+			<stop stop-color="#5aac00" offset="1"/>
+		</linearGradient>
+	</defs>
+	<rect x="4.5" y="4.5" width="503" height="503" rx="86" fill="#272727" stroke="#424240" stroke-width="9"/>
+	<circle cx="254" cy="256" r="160" fill="#7abd37" stroke="#424240" stroke-width="10"/>
+	<circle cx="254" cy="256" r="153" fill="url(#ImgurGreenGradient)"/>
+</svg>


### PR DESCRIPTION
original: https://web.archive.org/web/20141027192420/http://imgur.com/about/assets
twitter: denilsonsa

Drawn from scratch, [several months ago][1].

Sure, we can chop off a few more bytes by reducing the id/name of the gradient.

[1]: https://github.com/denilsonsa/denilsonsa.github.io/commits/master/icons/Imgur.svg